### PR TITLE
Making default constructor public--both were internal

### DIFF
--- a/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
+++ b/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
@@ -6,7 +6,7 @@ namespace ArguMint
    {
       private readonly ITypeInspector _typeInspector;
 
-      internal ArgumentAnalyzer() : this( new TypeInspector() )
+      public ArgumentAnalyzer() : this( new TypeInspector() )
       {
       }
 


### PR DESCRIPTION
Otherwise no one would be able to make an instance of this thing. Feels
a little weird to have an internal constructor just for testing purposes,
but I think it's weirder to expose an alternate path that isn't intended
to be used by the user. These classes weren't meant for third-party
extension, and it would only screw stuff up.
