### PR TITLE
Dispatching with better error info

### DIFF
--- a/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyArguments.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyArguments.cs
@@ -23,13 +23,13 @@
          set;
       }
 
-      public ArgumentErrorType? ArgumentErrorType
+      public ArgumentError ArgumentError
       {
          get;
          private set;
       }
 
       [ArgumentErrorHandler]
-      public void ArgumentHandler( ArgumentErrorType errorType ) => ArgumentErrorType = errorType;
+      public void ArgumentHandler( ArgumentError argumentError ) => ArgumentError = argumentError;
    }
 }

--- a/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
@@ -36,7 +36,7 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
 
          // Assert
 
-         argumentClass.ArgumentErrorType.Should().Be( ArgumentErrorType.ArgumentMissing );
+         argumentClass.ArgumentError.ErrorType.Should().Be( ArgumentErrorType.ArgumentMissing );
       }
 
       public void FileCopyScenario_ContainsOptionalForceParameter_MatchesArguments()

--- a/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
@@ -37,6 +37,7 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
          // Assert
 
          argumentClass.ArgumentError.ErrorType.Should().Be( ArgumentErrorType.ArgumentMissing );
+         argumentClass.ArgumentError.Properties["PropertyName"].Should().Be( nameof( FileCopyArguments.DestinationFile ) );
       }
 
       public void FileCopyScenario_ContainsOptionalForceParameter_MatchesArguments()

--- a/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
@@ -82,7 +82,7 @@ namespace ArguMint.UnitTests
 
          // Assert
 
-         handlerDispatcherMock.Verify( hd => hd.DispatchArgumentError( It.IsAny<object>(), errorType ), Times.Once() );
+         handlerDispatcherMock.Verify( hd => hd.DispatchArgumentError( It.IsAny<object>(), It.Is<ArgumentError>( ae => ae.ErrorType == errorType ) ), Times.Once() );
       }
    }
 }

--- a/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
@@ -65,14 +65,14 @@ namespace ArguMint.UnitTests
       public void Analyze_RuleMatcherThrowsArgumentErrorException_CallsArgumentHandler()
       {
          var stringArgs = ArrayHelper.Create( "OneArg" );
-         const ArgumentErrorType errorType = ArgumentErrorType.TypeMismatch;
+         const ArgumentErrorType errorType = ArgumentErrorType.Unspecified;
 
          // Arrange
 
          var handlerDispatcherMock = new Mock<IHandlerDispatcher>();
 
          var ruleMatcherMock = new Mock<IRuleMatcher>();
-         ruleMatcherMock.Setup( rm => rm.Match( It.IsAny<object>(), stringArgs ) ).Throws( new ArgumentErrorException( errorType ) );
+         ruleMatcherMock.Setup( rm => rm.Match( It.IsAny<object>(), stringArgs ) ).Throws( new ArgumentErrorException( errorType, null ) );
 
          // Act
 

--- a/src/ArguMint/ArguMint.UnitTests/HandlerDispatcherTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/HandlerDispatcherTests.cs
@@ -72,7 +72,7 @@ namespace ArguMint.UnitTests
       {
          var handlerDispatcher = new HandlerDispatcher( null );
 
-         Action dispatchArgumentError = () => handlerDispatcher.DispatchArgumentError( null, ArgumentErrorType.Unspecified );
+         Action dispatchArgumentError = () => handlerDispatcher.DispatchArgumentError( null, new ArgumentError( ArgumentErrorType.Unspecified ) );
 
          dispatchArgumentError.ShouldThrow<ArgumentException>();
       }
@@ -94,7 +94,7 @@ namespace ArguMint.UnitTests
 
          var handlerDispatcher = new HandlerDispatcher( typeInspectorMock.Object );
 
-         handlerDispatcher.DispatchArgumentError( argumentClassDoesNotMatter, ArgumentErrorType.Unspecified );
+         handlerDispatcher.DispatchArgumentError( argumentClassDoesNotMatter, new ArgumentError( ArgumentErrorType.Unspecified ) );
 
          // Assert
 
@@ -108,7 +108,7 @@ namespace ArguMint.UnitTests
          // Arrange
 
          var markedMethodMock = new Mock<IMarkedMethod<ArgumentErrorHandlerAttribute>>();
-         markedMethodMock.SetupGet( mm => mm.ParameterTypes ).Returns( ArrayHelper.Create( typeof( ArgumentErrorType ) ) );
+         markedMethodMock.SetupGet( mm => mm.ParameterTypes ).Returns( ArrayHelper.Create( typeof( ArgumentError ) ) );
          var markedMethods = ArrayHelper.Create( markedMethodMock.Object );
 
          var typeInspectorMock = new Mock<ITypeInspector>();
@@ -120,11 +120,13 @@ namespace ArguMint.UnitTests
 
          var handlerDispatcher = new HandlerDispatcher( typeInspectorMock.Object );
 
-         handlerDispatcher.DispatchArgumentError( argumentClassDoesNotMatter, errorType );
+         handlerDispatcher.DispatchArgumentError( argumentClassDoesNotMatter, new ArgumentError( errorType ) );
 
          // Assert
 
-         markedMethodMock.Verify( mm => mm.Invoke( argumentClassDoesNotMatter, It.Is<object[]>( a => ((ArgumentErrorType) a[0]) == errorType ) ), Times.Once() );
+         markedMethodMock.Verify( mm => mm.Invoke( argumentClassDoesNotMatter,
+            It.Is<object[]>( a => ((ArgumentError) a[0]).ErrorType == errorType ) ),
+            Times.Once() );
       }
 
       public void DispatchArgumentError_FindsMultipleErrorHandlers_ThrowsArgumentConfigurationException()
@@ -143,7 +145,7 @@ namespace ArguMint.UnitTests
 
          var handlerDispatcher = new HandlerDispatcher( typeInspectorMock.Object );
 
-         Action dispatchArgumentError = () => handlerDispatcher.DispatchArgumentError( argumentClassDoesNotMatter, ArgumentErrorType.Unspecified );
+         Action dispatchArgumentError = () => handlerDispatcher.DispatchArgumentError( argumentClassDoesNotMatter, new ArgumentError( ArgumentErrorType.Unspecified ) );
 
          // Assert
 

--- a/src/ArguMint/ArguMint/ArguMint.csproj
+++ b/src/ArguMint/ArguMint/ArguMint.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ArgumentAnalyzer.cs" />
     <Compile Include="ArgumentAttribute.cs" />
     <Compile Include="ArgumentConfigurationException.cs" />
+    <Compile Include="ArgumentError.cs" />
     <Compile Include="ArgumentErrorException.cs" />
     <Compile Include="ArgumentErrorHandlerAttribute.cs" />
     <Compile Include="ArgumentErrorType.cs" />

--- a/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
+++ b/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
@@ -41,7 +41,7 @@ namespace ArguMint
          }
          catch ( ArgumentErrorException ex )
          {
-            _handlerDispatcher.DispatchArgumentError( argumentClass, new ArgumentError( ex.ErrorType ) );
+            _handlerDispatcher.DispatchArgumentError( argumentClass, new ArgumentError( ex.ErrorType, ex.Properties ) );
          }
 
          return argumentClass;

--- a/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
+++ b/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
@@ -41,7 +41,7 @@ namespace ArguMint
          }
          catch ( ArgumentErrorException ex )
          {
-            _handlerDispatcher.DispatchArgumentError( argumentClass, ex.ErrorType );
+            _handlerDispatcher.DispatchArgumentError( argumentClass, new ArgumentError( ex.ErrorType ) );
          }
 
          return argumentClass;

--- a/src/ArguMint/ArguMint/ArgumentError.cs
+++ b/src/ArguMint/ArguMint/ArgumentError.cs
@@ -2,5 +2,14 @@
 {
    public class ArgumentError
    {
+      public ArgumentErrorType ErrorType
+      {
+         get;
+      }
+
+      public ArgumentError( ArgumentErrorType errorType )
+      {
+         ErrorType = errorType;
+      }
    }
 }

--- a/src/ArguMint/ArguMint/ArgumentError.cs
+++ b/src/ArguMint/ArguMint/ArgumentError.cs
@@ -1,0 +1,6 @@
+﻿namespace ArguMint
+{
+   public class ArgumentError
+   {
+   }
+}

--- a/src/ArguMint/ArguMint/ArgumentError.cs
+++ b/src/ArguMint/ArguMint/ArgumentError.cs
@@ -1,4 +1,6 @@
-﻿namespace ArguMint
+﻿using System.Collections.Generic;
+
+namespace ArguMint
 {
    public class ArgumentError
    {
@@ -7,9 +9,42 @@
          get;
       }
 
+      public Dictionary<string, object> Properties
+      {
+         get;
+      }
+
       public ArgumentError( ArgumentErrorType errorType )
       {
          ErrorType = errorType;
+         Properties = new Dictionary<string, object>();
+      }
+
+      public ArgumentError( ArgumentErrorType errorType, Dictionary<string, object> properties )
+      {
+         ErrorType = errorType;
+         Properties = properties;
+      }
+
+      internal static void ThrowForTypeMismatch( string propertyName, string propertyType )
+      {
+         var properties = new Dictionary<string, object>
+         {
+            ["PropertyName"] = propertyName,
+            ["PropertyType"] = propertyType
+         };
+
+         throw new ArgumentErrorException( ArgumentErrorType.TypeMismatch, properties );
+      }
+
+      internal static void ThrowForArgumentMissing()
+      {
+         throw new ArgumentErrorException( ArgumentErrorType.ArgumentMissing, null );
+      }
+
+      public static void ThrowForPrefixArgumentHasNoValue()
+      {
+         throw new  ArgumentErrorException( ArgumentErrorType.PrefixArgumentHasNoValue, null );
       }
    }
 }

--- a/src/ArguMint/ArguMint/ArgumentError.cs
+++ b/src/ArguMint/ArguMint/ArgumentError.cs
@@ -37,9 +37,14 @@ namespace ArguMint
          throw new ArgumentErrorException( ArgumentErrorType.TypeMismatch, properties );
       }
 
-      internal static void ThrowForArgumentMissing()
+      internal static void ThrowForArgumentMissing( string propertyName )
       {
-         throw new ArgumentErrorException( ArgumentErrorType.ArgumentMissing, null );
+         var properties = new Dictionary<string, object>
+         {
+            ["PropertyName"] = propertyName,
+         };
+
+         throw new ArgumentErrorException( ArgumentErrorType.ArgumentMissing, properties );
       }
 
       public static void ThrowForPrefixArgumentHasNoValue()

--- a/src/ArguMint/ArguMint/ArgumentErrorException.cs
+++ b/src/ArguMint/ArguMint/ArgumentErrorException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace ArguMint
@@ -11,9 +12,15 @@ namespace ArguMint
          get;
       }
 
-      public ArgumentErrorException( ArgumentErrorType errorType )
+      public Dictionary<string, object> Properties
+      {
+         get;
+      }
+
+      public ArgumentErrorException( ArgumentErrorType errorType, Dictionary<string, object> properties )
       {
          ErrorType = errorType;
+         Properties = properties;
       }
 
       public ArgumentErrorException( string message )

--- a/src/ArguMint/ArguMint/HandlerDispatcher.cs
+++ b/src/ArguMint/ArguMint/HandlerDispatcher.cs
@@ -38,7 +38,7 @@ namespace ArguMint
          }
       }
 
-      public void DispatchArgumentError( object argumentClass, ArgumentErrorType errorType )
+      public void DispatchArgumentError( object argumentClass, ArgumentError argumentError )
       {
          var markedMethods = GetMarkedMethods<ArgumentErrorHandlerAttribute>( argumentClass );
 
@@ -50,9 +50,9 @@ namespace ArguMint
             {
                markedMethods[0].Invoke( argumentClass );
             }
-            else if ( parameterTypes.Length == 1 && parameterTypes[0] == typeof( ArgumentErrorType ) )
+            else if ( parameterTypes.Length == 1 && parameterTypes[0] == typeof( ArgumentError ) )
             {
-               markedMethods[0].Invoke( argumentClass, new object[] { errorType } );
+               markedMethods[0].Invoke( argumentClass, new object[] { argumentError } );
             }
          }
       }

--- a/src/ArguMint/ArguMint/IHandlerDispatcher.cs
+++ b/src/ArguMint/ArguMint/IHandlerDispatcher.cs
@@ -3,6 +3,6 @@
    internal interface IHandlerDispatcher
    {
       void DispatchArgumentsOmitted( object argumentClass );
-      void DispatchArgumentError( object argumentClass, ArgumentErrorType errorType );
+      void DispatchArgumentError( object argumentClass, ArgumentError argumentError );
    }
 }

--- a/src/ArguMint/ArguMint/PositionalRule.cs
+++ b/src/ArguMint/ArguMint/PositionalRule.cs
@@ -28,14 +28,14 @@
 
                if ( convertedValue == null )
                {
-                  throw new ArgumentErrorException( ArgumentErrorType.TypeMismatch );
+                  ArgumentError.ThrowForTypeMismatch( property.PropertyName, property.PropertyType.Name );
                }
 
                property.SetPropertyValue( argumentClass, convertedValue );
             }
             else
             {
-               throw new ArgumentErrorException( ArgumentErrorType.ArgumentMissing );
+               ArgumentError.ThrowForArgumentMissing();;
             }
          }
       }

--- a/src/ArguMint/ArguMint/PositionalRule.cs
+++ b/src/ArguMint/ArguMint/PositionalRule.cs
@@ -35,7 +35,7 @@
             }
             else
             {
-               ArgumentError.ThrowForArgumentMissing();;
+               ArgumentError.ThrowForArgumentMissing( property.PropertyName );;
             }
          }
       }

--- a/src/ArguMint/ArguMint/PrefixRule.cs
+++ b/src/ArguMint/ArguMint/PrefixRule.cs
@@ -20,14 +20,14 @@
 
                      if ( string.IsNullOrEmpty( value ) )
                      {
-                        throw new ArgumentErrorException( ArgumentErrorType.PrefixArgumentHasNoValue );
+                        ArgumentError.ThrowForPrefixArgumentHasNoValue();
                      }
 
                      object convertedValue = ValueConverter.Convert( value, property.PropertyType );
 
                      if ( convertedValue == null )
                      {
-                        throw new ArgumentErrorException( ArgumentErrorType.TypeMismatch );
+                        ArgumentError.ThrowForTypeMismatch( property.PropertyName, property.PropertyType.Name );
                      }
 
                      property.SetPropertyValue( argumentClass, convertedValue );
@@ -46,7 +46,7 @@
                   {
                      if ( index + 1 >= arguments.Length )
                      {
-                        throw new ArgumentErrorException( ArgumentErrorType.PrefixArgumentHasNoValue );
+                        ArgumentError.ThrowForPrefixArgumentHasNoValue();
                      }
 
                      string value = arguments[index + 1];


### PR DESCRIPTION
Currently the dispatcher allows an ArgumentErrorType enum to be supplied, indicating what type of thing occurred to cause the error in the first place. This doesn't provide a lot of scalability with supplying further info. Here we'll replace that guy with a class that can grow to contain other things.
