### PR TITLE
Using gci over dir to find test assemblies

### DIFF
--- a/runTests.ps1
+++ b/runTests.ps1
@@ -1,2 +1,2 @@
-$testAssemblies = dir *Test*.dll -r | ? { $_.FullName.ToLower().Contains( "bin" ) } | Sort-Object Name -Unique
+$testAssemblies = gci *Test*.dll -r | ? { $_.FullName.ToLower().Contains( "bin" ) } | Sort-Object Name -Unique
 .\src\ArguMint\packages\Fixie.1.0.2\lib\net45\Fixie.Console.exe $testAssemblies


### PR DESCRIPTION
I have dir aliased to something else, so this screws up my runTests script for my machine. Changing it to gci so it won't interfere. Doesn't make a difference for continuous builds.