### PR TITLE
Passing "token" objects around instead of raw string parameters

### DIFF
--- a/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
@@ -23,6 +23,7 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
 
          argumentClass.SourceFile.Should().Be( sourceFile );
          argumentClass.DestinationFile.Should().Be( destinationFile );
+         argumentClass.ForceCopy.Should().BeFalse();
       }
 
       [Fact]

--- a/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
@@ -84,5 +84,25 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
          argumentClass.DestinationFile.Should().Be( forceFlag );
          argumentClass.ForceCopy.Should().BeFalse();
       }
+
+      [Fact]
+      public void FileCopyScenario_OnlyHasSourceAndForceParameters_MatchesThemToSourceAndDestination()
+      {
+         const string sourceFile = @"C:\Temp\Source.txt";
+         const string forceFlag = "/force";
+         var stringArgs = ArrayHelper.Create( sourceFile, forceFlag );
+
+         // Act
+
+         var argumentAnalyzer = new ArgumentAnalyzer();
+
+         var argumentClass = argumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
+
+         // Assert
+
+         argumentClass.SourceFile.Should().Be( sourceFile );
+         argumentClass.DestinationFile.Should().Be( forceFlag );
+         argumentClass.ForceCopy.Should().BeFalse();
+      }
    }
 }

--- a/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
@@ -1,6 +1,6 @@
-﻿using ArguMint.TestCommon.Helpers;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Xunit;
+using ArguMint.TestCommon.Helpers;
 
 namespace ArguMint.IntegrationTests.Scenarios.FileCopy
 {

--- a/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
@@ -63,5 +63,26 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
          argumentClass.DestinationFile.Should().Be( destinationFile );
          argumentClass.ForceCopy.Should().BeTrue();
       }
+
+      [Fact]
+      public void FileCopyScenario_MixesUpForceAndDestinationParameters_DestinationIsForceAndForceFlagIsFalse()
+      {
+         const string sourceFile = @"C:\Temp\Source.txt";
+         const string destinationFile = @"C:\Temp\Destination.txt";
+         const string forceFlag = "/force";
+         var stringArgs = ArrayHelper.Create( sourceFile, forceFlag, destinationFile );
+
+         // Act
+
+         var argumentAnalyzer = new ArgumentAnalyzer();
+
+         var argumentClass = argumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
+
+         // Assert
+
+         argumentClass.SourceFile.Should().Be( sourceFile );
+         argumentClass.DestinationFile.Should().Be( forceFlag );
+         argumentClass.ForceCopy.Should().BeFalse();
+      }
    }
 }

--- a/src/ArguMint/ArguMint.TestCommon/Properties/AssemblyInfo.cs
+++ b/src/ArguMint/ArguMint.TestCommon/Properties/AssemblyInfo.cs
@@ -1,36 +1,35 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ArguMint.TestCommon")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("ArguMint.TestCommon")]
+[assembly: AssemblyTitle( "ArguMint.TestCommon" )]
+[assembly: AssemblyDescription( "" )]
+[assembly: AssemblyConfiguration( "" )]
+[assembly: AssemblyCompany( "" )]
+[assembly: AssemblyProduct( "ArguMint.TestCommon" )]
 [assembly: AssemblyCopyright( "Copyright © 2015-2016 Alex Novak" )]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyTrademark( "" )]
+[assembly: AssemblyCulture( "" )]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+[assembly: ComVisible( false )]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("b8f28747-0a5b-4eca-b210-5658fcb05725")]
+[assembly: Guid( "b8f28747-0a5b-4eca-b210-5658fcb05725" )]
 
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion( "1.0.0.0" )]
+[assembly: AssemblyFileVersion( "1.0.0.0" )]

--- a/src/ArguMint/ArguMint.UnitTests/ArguMint.UnitTests.csproj
+++ b/src/ArguMint/ArguMint.UnitTests/ArguMint.UnitTests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Dummies\DummyAttributePropertyPrivateSetter.cs" />
     <Compile Include="Helpers\MarkedPropertyHelper.cs" />
     <Compile Include="Helpers\ObjectExtensions.cs" />
+    <Compile Include="Helpers\TokenHelper.cs" />
     <Compile Include="MarkedPropertyTests.cs" />
     <Compile Include="PositionalRuleTests.cs" />
     <Compile Include="PrefixRuleTests.cs" />

--- a/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Moq;
 using FluentAssertions;
 using Xunit;
@@ -50,6 +51,7 @@ namespace ArguMint.UnitTests
       public void Analyze_HasArguments_CallsRuleMatcher()
       {
          var stringArgs = ArrayHelper.Create( "OneArg" );
+         var tokens = TokenHelper.CreateArray( stringArgs );
 
          // Arrange
 
@@ -63,13 +65,16 @@ namespace ArguMint.UnitTests
 
          // Assert
 
-         ruleMatcherMock.Verify( rm => rm.Match( It.IsAny<object>(), stringArgs ), Times.Once() );
+         ruleMatcherMock.Verify( rm => rm.Match( It.IsAny<object>(),
+            It.Is<ArgumentToken[]>( at => at.All( token => stringArgs.Contains( token.Token ) ) ) ),
+            Times.Once() );
       }
 
       [Fact]
       public void Analyze_RuleMatcherThrowsArgumentErrorException_CallsArgumentHandler()
       {
          var stringArgs = ArrayHelper.Create( "OneArg" );
+         var tokens = TokenHelper.CreateArray( stringArgs );
          const ArgumentErrorType errorType = ArgumentErrorType.Unspecified;
 
          // Arrange
@@ -77,7 +82,7 @@ namespace ArguMint.UnitTests
          var handlerDispatcherMock = new Mock<IHandlerDispatcher>();
 
          var ruleMatcherMock = new Mock<IRuleMatcher>();
-         ruleMatcherMock.Setup( rm => rm.Match( It.IsAny<object>(), stringArgs ) ).Throws( new ArgumentErrorException( errorType, null ) );
+         ruleMatcherMock.Setup( rm => rm.Match( It.IsAny<object>(), It.IsAny<ArgumentToken[]>() ) ).Throws( new ArgumentErrorException( errorType, null ) );
 
          // Act
 

--- a/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
@@ -51,7 +51,6 @@ namespace ArguMint.UnitTests
       public void Analyze_HasArguments_CallsRuleMatcher()
       {
          var stringArgs = ArrayHelper.Create( "OneArg" );
-         var tokens = TokenHelper.CreateArray( stringArgs );
 
          // Arrange
 
@@ -74,7 +73,6 @@ namespace ArguMint.UnitTests
       public void Analyze_RuleMatcherThrowsArgumentErrorException_CallsArgumentHandler()
       {
          var stringArgs = ArrayHelper.Create( "OneArg" );
-         var tokens = TokenHelper.CreateArray( stringArgs );
          const ArgumentErrorType errorType = ArgumentErrorType.Unspecified;
 
          // Arrange
@@ -92,7 +90,9 @@ namespace ArguMint.UnitTests
 
          // Assert
 
-         handlerDispatcherMock.Verify( hd => hd.DispatchArgumentError( It.IsAny<object>(), It.Is<ArgumentError>( ae => ae.ErrorType == errorType ) ), Times.Once() );
+         handlerDispatcherMock.Verify( hd => hd.DispatchArgumentError( It.IsAny<object>(),
+            It.Is<ArgumentError>( ae => ae.ErrorType == errorType ) ),
+            Times.Once() );
       }
    }
 }

--- a/src/ArguMint/ArguMint.UnitTests/Helpers/TokenHelper.cs
+++ b/src/ArguMint/ArguMint.UnitTests/Helpers/TokenHelper.cs
@@ -1,0 +1,10 @@
+﻿using System.Linq;
+
+namespace ArguMint.UnitTests.Helpers
+{
+   internal static class TokenHelper
+   {
+      public static ArgumentToken[] CreateArray( params string[] tokens )
+         => tokens.Select( s => new ArgumentToken( s ) ).ToArray();
+   }
+}

--- a/src/ArguMint/ArguMint.UnitTests/PositionalRuleTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/PositionalRuleTests.cs
@@ -2,6 +2,7 @@
 using Moq;
 using FluentAssertions;
 using ArguMint.TestCommon.Helpers;
+using ArguMint.UnitTests.Helpers;
 using Xunit;
 
 namespace ArguMint.UnitTests
@@ -12,7 +13,7 @@ namespace ArguMint.UnitTests
       public void Match_DoesNotSpecifyPosition_DoesNotSetProperty()
       {
          object argumentClass = "ThisDoesNotMatter";
-         var stringArgs = new string[0];
+         var tokens = new ArgumentToken[0];
 
          // Arrange
 
@@ -23,7 +24,7 @@ namespace ArguMint.UnitTests
 
          var positionalRule = new PositionalRule();
 
-         positionalRule.Match( argumentClass, markedPropertyMock.Object, stringArgs );
+         positionalRule.Match( argumentClass, markedPropertyMock.Object, tokens );
 
          // Assert
 
@@ -51,7 +52,7 @@ namespace ArguMint.UnitTests
 
          var positionalRule = new PositionalRule();
 
-         positionalRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( argument ) );
+         positionalRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( argument ) );
 
          // Assert
 
@@ -79,7 +80,7 @@ namespace ArguMint.UnitTests
 
          var positionalRule = new PositionalRule();
 
-         Action match = () => positionalRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( argument ) );
+         Action match = () => positionalRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( argument ) );
 
          // Assert
 
@@ -107,7 +108,7 @@ namespace ArguMint.UnitTests
 
          var positionalRule = new PositionalRule();
 
-         Action match = () => positionalRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( argument ) );
+         Action match = () => positionalRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( argument ) );
 
          // Assert
 

--- a/src/ArguMint/ArguMint.UnitTests/PositionalRuleTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/PositionalRuleTests.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using Moq;
 using FluentAssertions;
-using ArguMint.TestCommon.Helpers;
-using ArguMint.UnitTests.Helpers;
 using Xunit;
+using ArguMint.UnitTests.Helpers;
 
 namespace ArguMint.UnitTests
 {

--- a/src/ArguMint/ArguMint.UnitTests/PrefixRuleTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/PrefixRuleTests.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using FluentAssertions;
 using Moq;
-using ArguMint.TestCommon.Helpers;
-using ArguMint.UnitTests.Helpers;
 using Xunit;
+using ArguMint.UnitTests.Helpers;
 
 namespace ArguMint.UnitTests
 {

--- a/src/ArguMint/ArguMint.UnitTests/PrefixRuleTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/PrefixRuleTests.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using Moq;
 using ArguMint.TestCommon.Helpers;
+using ArguMint.UnitTests.Helpers;
 using Xunit;
 
 namespace ArguMint.UnitTests
@@ -26,10 +27,11 @@ namespace ArguMint.UnitTests
          // Act
 
          string argument = $"{prefix}{value}";
+         var tokens = TokenHelper.CreateArray( argument );
 
          var prefixRule = new PrefixRule();
 
-         prefixRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( argument ) );
+         prefixRule.Match( argumentClass, markedPropertyMock.Object, tokens );
 
          // Assert
 
@@ -56,7 +58,7 @@ namespace ArguMint.UnitTests
 
          var prefixRule = new PrefixRule();
 
-         Action match = () => prefixRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( prefix ) );
+         Action match = () => prefixRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( prefix ) );
 
          // Assert
 
@@ -85,7 +87,7 @@ namespace ArguMint.UnitTests
 
          var prefixRule = new PrefixRule();
 
-         prefixRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( prefix, value ) );
+         prefixRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( prefix, value ) );
 
          // Assert
 
@@ -113,7 +115,7 @@ namespace ArguMint.UnitTests
 
          var prefixRule = new PrefixRule();
 
-         Action match = () => prefixRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( prefix ) );
+         Action match = () => prefixRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( prefix ) );
 
          // Assert
 
@@ -141,7 +143,7 @@ namespace ArguMint.UnitTests
 
          var prefixRule = new PrefixRule();
 
-         prefixRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( prefix ) );
+         prefixRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( prefix ) );
 
          // Assert
 
@@ -170,7 +172,7 @@ namespace ArguMint.UnitTests
 
          var prefixRule = new PrefixRule();
 
-         prefixRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( argument ) );
+         prefixRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( argument ) );
 
          // Assert
 
@@ -199,7 +201,7 @@ namespace ArguMint.UnitTests
 
          var prefixRule = new PrefixRule();
 
-         Action match = () => prefixRule.Match( argumentClass, markedPropertyMock.Object, ArrayHelper.Create( argument ) );
+         Action match = () => prefixRule.Match( argumentClass, markedPropertyMock.Object, TokenHelper.CreateArray( argument ) );
 
          // Assert
 

--- a/src/ArguMint/ArguMint.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/ArguMint/ArguMint.UnitTests/Properties/AssemblyInfo.cs
@@ -1,8 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle( "ArguMint.UnitTests" )]
@@ -14,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible( false )]
 
@@ -25,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion( "1.0.0.0" )]

--- a/src/ArguMint/ArguMint.UnitTests/RuleMatcherTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/RuleMatcherTests.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using Moq;
 using ArguMint.TestCommon.Helpers;
+using ArguMint.UnitTests.Helpers;
 using Xunit;
 
 namespace ArguMint.UnitTests
@@ -52,18 +53,18 @@ namespace ArguMint.UnitTests
          // Act
 
          object argumentClass = "DoesNotMatterWhatThisIs";
-         var stringArgs = ArrayHelper.Create( "SomeArgument" );
+         var tokens = TokenHelper.CreateArray( "SomeArgument" );
 
          var ruleMatcher = new RuleMatcher( ruleProviderMock.Object, typeInspectorMock.Object );
-         ruleMatcher.Match( argumentClass, stringArgs );
+         ruleMatcher.Match( argumentClass, tokens );
 
          // Assert
 
-         ruleOneMock.Verify( r => r.Match( argumentClass, propertyOneMock.Object, stringArgs ), Times.Once() );
-         ruleTwoMock.Verify( r => r.Match( argumentClass, propertyOneMock.Object, stringArgs ), Times.Once() );
+         ruleOneMock.Verify( r => r.Match( argumentClass, propertyOneMock.Object, tokens ), Times.Once() );
+         ruleTwoMock.Verify( r => r.Match( argumentClass, propertyOneMock.Object, tokens ), Times.Once() );
 
-         ruleOneMock.Verify( r => r.Match( argumentClass, propertyTwoMock.Object, stringArgs ), Times.Once() );
-         ruleTwoMock.Verify( r => r.Match( argumentClass, propertyTwoMock.Object, stringArgs ), Times.Once() );
+         ruleOneMock.Verify( r => r.Match( argumentClass, propertyTwoMock.Object, tokens ), Times.Once() );
+         ruleTwoMock.Verify( r => r.Match( argumentClass, propertyTwoMock.Object, tokens ), Times.Once() );
       }
    }
 }

--- a/src/ArguMint/ArguMint.UnitTests/RuleMatcherTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/RuleMatcherTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using FluentAssertions;
 using Moq;
+using Xunit;
 using ArguMint.TestCommon.Helpers;
 using ArguMint.UnitTests.Helpers;
-using Xunit;
 
 namespace ArguMint.UnitTests
 {

--- a/src/ArguMint/ArguMint/ArguMint.csproj
+++ b/src/ArguMint/ArguMint/ArguMint.csproj
@@ -52,6 +52,7 @@
     <Compile Include="ArgumentPosition.cs" />
     <Compile Include="ArgumentPositionExtensions.cs" />
     <Compile Include="ArgumentsOmittedHandlerAttribute.cs" />
+    <Compile Include="ArgumentToken.cs" />
     <Compile Include="IArgumentRule.cs" />
     <Compile Include="HandlerDispatcher.cs" />
     <Compile Include="IHandlerDispatcher.cs" />

--- a/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
+++ b/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace ArguMint
 {
@@ -37,7 +38,9 @@ namespace ArguMint
 
          try
          {
-            _ruleMatcher.Match( argumentClass, arguments );
+            var argumentTokens = arguments.Select( s => new ArgumentToken( s ) ).ToArray();
+
+            _ruleMatcher.Match( argumentClass, argumentTokens );
          }
          catch ( ArgumentErrorException ex )
          {

--- a/src/ArguMint/ArguMint/ArgumentToken.cs
+++ b/src/ArguMint/ArguMint/ArgumentToken.cs
@@ -1,0 +1,21 @@
+﻿namespace ArguMint
+{
+   internal class ArgumentToken
+   {
+      public string Token
+      {
+         get;
+      }
+
+      public bool IsMatched
+      {
+         get;
+         set;
+      }
+
+      public ArgumentToken( string token )
+      {
+         Token = token;
+      }
+   }
+}

--- a/src/ArguMint/ArguMint/ArgumentToken.cs
+++ b/src/ArguMint/ArguMint/ArgumentToken.cs
@@ -17,5 +17,7 @@
       {
          Token = token;
       }
+
+      public override string ToString() => $"{Token}, IsMatched={IsMatched}";
    }
 }

--- a/src/ArguMint/ArguMint/IArgumentRule.cs
+++ b/src/ArguMint/ArguMint/IArgumentRule.cs
@@ -2,6 +2,6 @@
 {
    internal interface IArgumentRule
    {
-      void Match( object argumentClass, IMarkedProperty<ArgumentAttribute> property, string[] arguments );
+      void Match( object argumentClass, IMarkedProperty<ArgumentAttribute> property, ArgumentToken[] arguments );
    }
 }

--- a/src/ArguMint/ArguMint/IRuleMatcher.cs
+++ b/src/ArguMint/ArguMint/IRuleMatcher.cs
@@ -2,6 +2,6 @@
 {
    internal interface IRuleMatcher
    {
-      void Match( object argumentClass, string[] arguments );
+      void Match( object argumentClass, ArgumentToken[] arguments );
    }
 }

--- a/src/ArguMint/ArguMint/PositionalRule.cs
+++ b/src/ArguMint/ArguMint/PositionalRule.cs
@@ -8,7 +8,7 @@
          {
             foreach ( var argument in arguments )
             {
-               if ( argument.Token == property.Attribute.Argument )
+               if ( !argument.IsMatched && argument.Token == property.Attribute.Argument )
                {
                   if ( property.PropertyType == typeof( bool ) )
                   {
@@ -32,6 +32,7 @@
                }
 
                property.SetPropertyValue( argumentClass, convertedValue );
+               arguments[index].IsMatched = true;
             }
             else
             {

--- a/src/ArguMint/ArguMint/PositionalRule.cs
+++ b/src/ArguMint/ArguMint/PositionalRule.cs
@@ -2,13 +2,13 @@
 {
    internal class PositionalRule : IArgumentRule
    {
-      public void Match( object argumentClass, IMarkedProperty<ArgumentAttribute> property, string[] arguments )
+      public void Match( object argumentClass, IMarkedProperty<ArgumentAttribute> property, ArgumentToken[] arguments )
       {
          if ( property.Attribute.Position == ArgumentPosition.Any )
          {
-            foreach ( string argument in arguments )
+            foreach ( var argument in arguments )
             {
-               if ( argument == property.Attribute.Argument )
+               if ( argument.Token == property.Attribute.Argument )
                {
                   if ( property.PropertyType == typeof( bool ) )
                   {
@@ -24,7 +24,7 @@
 
             if ( arguments.Length >= index + 1 )
             {
-               object convertedValue = ValueConverter.Convert( arguments[index], property.PropertyType );
+               object convertedValue = ValueConverter.Convert( arguments[index].Token, property.PropertyType );
 
                if ( convertedValue == null )
                {

--- a/src/ArguMint/ArguMint/PrefixRule.cs
+++ b/src/ArguMint/ArguMint/PrefixRule.cs
@@ -10,7 +10,7 @@
             {
                foreach ( var argument in arguments )
                {
-                  if ( argument.Token == property.Attribute.Argument && property.PropertyType == typeof( bool ) )
+                  if ( !argument.IsMatched && argument.Token == property.Attribute.Argument && property.PropertyType == typeof( bool ) )
                   {
                      property.SetPropertyValue( argumentClass, true );
                   }

--- a/src/ArguMint/ArguMint/PrefixRule.cs
+++ b/src/ArguMint/ArguMint/PrefixRule.cs
@@ -2,21 +2,21 @@
 {
    internal class PrefixRule : IArgumentRule
    {
-      public void Match( object argumentClass, IMarkedProperty<ArgumentAttribute> property, string[] arguments )
+      public void Match( object argumentClass, IMarkedProperty<ArgumentAttribute> property, ArgumentToken[] arguments )
       {
          if ( !string.IsNullOrEmpty( property.Attribute.Argument ) )
          {
             if ( property.Attribute.Spacing == Spacing.None )
             {
-               foreach ( string argument in arguments )
+               foreach ( var argument in arguments )
                {
-                  if ( argument == property.Attribute.Argument && property.PropertyType == typeof( bool ) )
+                  if ( argument.Token == property.Attribute.Argument && property.PropertyType == typeof( bool ) )
                   {
                      property.SetPropertyValue( argumentClass, true );
                   }
-                  else if ( argument.StartsWith( property.Attribute.Argument ) )
+                  else if ( argument.Token.StartsWith( property.Attribute.Argument ) )
                   {
-                     string value = argument.Replace( property.Attribute.Argument, string.Empty );
+                     string value = argument.Token.Replace( property.Attribute.Argument, string.Empty );
 
                      if ( string.IsNullOrEmpty( value ) )
                      {
@@ -40,7 +40,7 @@
 
                for ( int index = 0; index < arguments.Length; index++ )
                {
-                  string thisArgument = arguments[index].Trim();
+                  string thisArgument = arguments[index].Token.Trim();
 
                   if ( thisArgument == argumentString )
                   {
@@ -49,7 +49,7 @@
                         ArgumentError.ThrowForPrefixArgumentHasNoValue( property.PropertyName );
                      }
 
-                     string value = arguments[index + 1];
+                     string value = arguments[index + 1].Token;
                      property.SetPropertyValue( argumentClass, value );
                   }
                }

--- a/src/ArguMint/ArguMint/RuleMatcher.cs
+++ b/src/ArguMint/ArguMint/RuleMatcher.cs
@@ -11,7 +11,7 @@ namespace ArguMint
          _typeInspector = typeInspector;
       }
 
-      public void Match( object argumentClass, string[] arguments )
+      public void Match( object argumentClass, ArgumentToken[] arguments )
       {
          var markedProperties = _typeInspector.GetMarkedProperties<ArgumentAttribute>( argumentClass.GetType() );
 


### PR DESCRIPTION
This leaves us a degree of wiggle room, dealing in objects (that we can extend later for our internal purposes) instead of raw strings (that we can't adjust if we have a future need). That "extra stuff we may need" already contains an "is matched" flag on the token, so we can apply lots of logic to the list of tokens and know if we've already matched it on another rule.