### PR TITLE
No longer create an instance of the analyzer for use

### DIFF
--- a/src/ArguMint/ArguMint.IntegrationTests/ArgumentAnalyzerTests.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/ArgumentAnalyzerTests.cs
@@ -29,9 +29,7 @@ namespace ArguMint.IntegrationTests
 
          var stringArgs = ArrayHelper.Create( fileName );
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var arguments = ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentClass.Type, stringArgs );
+         var arguments = ArgumentAnalyzerHelper.Analyze( argumentClass.Type, stringArgs );
 
          // Assert
 
@@ -65,9 +63,7 @@ namespace ArguMint.IntegrationTests
 
          var stringArgs = ArrayHelper.Create( firstArgument, secondArgument );
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var arguments = ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentClass.Type, stringArgs );
+         var arguments = ArgumentAnalyzerHelper.Analyze( argumentClass.Type, stringArgs );
 
          // Assert
 
@@ -94,9 +90,7 @@ namespace ArguMint.IntegrationTests
 
          var stringArgs = ArrayHelper.Create( "oneargumentbutnottwo" );
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var arguments = ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentClass.Type, stringArgs );
+         var arguments = ArgumentAnalyzerHelper.Analyze( argumentClass.Type, stringArgs );
 
          // Assert
 
@@ -120,9 +114,7 @@ namespace ArguMint.IntegrationTests
 
          var stringArgs = ArrayHelper.Create( $"/f:{fileName}" );
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var arguments = ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentClass.Type, stringArgs );
+         var arguments = ArgumentAnalyzerHelper.Analyze( argumentClass.Type, stringArgs );
 
          // Assert
 
@@ -146,9 +138,7 @@ namespace ArguMint.IntegrationTests
 
          var stringArgs = ArrayHelper.Create( "-filename", fileName );
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var arguments = ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentClass.Type, stringArgs );
+         var arguments = ArgumentAnalyzerHelper.Analyze( argumentClass.Type, stringArgs );
 
          // Assert
 
@@ -175,9 +165,7 @@ namespace ArguMint.IntegrationTests
 
          var stringArgs = ArrayHelper.Create( maxSize.ToString() );
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var arguments = ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentClass.Type, stringArgs );
+         var arguments = ArgumentAnalyzerHelper.Analyze( argumentClass.Type, stringArgs );
 
          // Assert
 
@@ -204,9 +192,7 @@ namespace ArguMint.IntegrationTests
 
          var stringArgs = ArrayHelper.Create( charValue.ToString() );
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var arguments = ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentClass.Type, stringArgs );
+         var arguments = ArgumentAnalyzerHelper.Analyze( argumentClass.Type, stringArgs );
 
          // Assert
 
@@ -232,9 +218,7 @@ namespace ArguMint.IntegrationTests
 
          // Act
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentsClass.Type, new string[0] );
+         ArgumentAnalyzerHelper.Analyze( argumentsClass.Type, new string[0] );
 
          // Assert
 

--- a/src/ArguMint/ArguMint.IntegrationTests/Helpers/ArgumentAnalyzerHelper.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Helpers/ArgumentAnalyzerHelper.cs
@@ -5,9 +5,9 @@ namespace ArguMint.TestCommon.Helpers
 {
    public static class ArgumentAnalyzerHelper
    {
-      public static object Analyze( ArgumentAnalyzer argumentAnalyzer, Type argumentClassType, string[] arguments )
+      public static object Analyze( Type argumentClassType, string[] arguments )
       {
-         var analyzeMethod = argumentAnalyzer.GetType().GetMethod( "Analyze", BindingFlags.Public | BindingFlags.Instance );
+         var analyzeMethod = typeof( ArgumentAnalyzer ).GetMethod( "Analyze", BindingFlags.Public | BindingFlags.Static );
          var closedAnalyzeMethod = analyzeMethod.MakeGenericMethod( argumentClassType );
 
          var parameters = new object[]
@@ -17,7 +17,7 @@ namespace ArguMint.TestCommon.Helpers
 
          try
          {
-            return closedAnalyzeMethod.Invoke( argumentAnalyzer, parameters );
+            return closedAnalyzeMethod.Invoke( null, parameters );
          }
          catch ( TargetInvocationException ex ) when ( ex.InnerException != null )
          {

--- a/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
+++ b/src/ArguMint/ArguMint.IntegrationTests/Scenarios/FileCopy/FileCopyScenarioTests.cs
@@ -15,9 +15,7 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
 
          // Act
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var argumentClass = argumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
+         var argumentClass = ArgumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
 
          // Asserts
 
@@ -34,9 +32,7 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
 
          // Act
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var argumentClass = argumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
+         var argumentClass = ArgumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
 
          // Assert
 
@@ -53,9 +49,7 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
 
          // Act
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var argumentClass = argumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
+         var argumentClass = ArgumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
 
          // Asserts
 
@@ -74,9 +68,7 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
 
          // Act
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var argumentClass = argumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
+         var argumentClass = ArgumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
 
          // Assert
 
@@ -94,9 +86,7 @@ namespace ArguMint.IntegrationTests.Scenarios.FileCopy
 
          // Act
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         var argumentClass = argumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
+         var argumentClass = ArgumentAnalyzer.Analyze<FileCopyArguments>( stringArgs );
 
          // Assert
 

--- a/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/ArgumentAnalyzerTests.cs
@@ -22,9 +22,7 @@ namespace ArguMint.UnitTests
 
          // Act
 
-         var argumentAnalyzer = new ArgumentAnalyzer();
-
-         Action analyze = () => ArgumentAnalyzerHelper.Analyze( argumentAnalyzer, argumentClass.Type, null );
+         Action analyze = () => ArgumentAnalyzerHelper.Analyze( argumentClass.Type, null );
 
          analyze.ShouldThrow<ArgumentException>();
       }
@@ -40,7 +38,7 @@ namespace ArguMint.UnitTests
 
          var argumentAnalyzer = new ArgumentAnalyzer( handlerDispatcherMock.Object, null );
 
-         argumentAnalyzer.Analyze<DontCare>( new string[0] );
+         argumentAnalyzer.AnalyzeCore<DontCare>( new string[0] );
 
          // Assert
 
@@ -60,7 +58,7 @@ namespace ArguMint.UnitTests
 
          var argumentAnalyzer = new ArgumentAnalyzer( null, ruleMatcherMock.Object );
 
-         argumentAnalyzer.Analyze<DontCare>( stringArgs );
+         argumentAnalyzer.AnalyzeCore<DontCare>( stringArgs );
 
          // Assert
 
@@ -86,7 +84,7 @@ namespace ArguMint.UnitTests
 
          var argumentAnalyzer = new ArgumentAnalyzer( handlerDispatcherMock.Object, ruleMatcherMock.Object );
 
-         argumentAnalyzer.Analyze<DontCare>( stringArgs );
+         argumentAnalyzer.AnalyzeCore<DontCare>( stringArgs );
 
          // Assert
 

--- a/src/ArguMint/ArguMint.UnitTests/Helpers/ArgumentAnalyzerHelper.cs
+++ b/src/ArguMint/ArguMint.UnitTests/Helpers/ArgumentAnalyzerHelper.cs
@@ -5,9 +5,9 @@ namespace ArguMint.UnitTests.Helpers
 {
    public static class ArgumentAnalyzerHelper
    {
-      public static object Analyze( ArgumentAnalyzer argumentAnalyzer, Type argumentClassType, string[] arguments )
+      public static object Analyze( Type argumentClassType, string[] arguments )
       {
-         var analyzeMethod = argumentAnalyzer.GetType().GetMethod( "Analyze", BindingFlags.Public | BindingFlags.Instance );
+         var analyzeMethod = typeof( ArgumentAnalyzer ).GetMethod( "Analyze", BindingFlags.Public | BindingFlags.Static );
          var closedAnalyzeMethod = analyzeMethod.MakeGenericMethod( argumentClassType );
 
          var parameters = new object[]
@@ -17,7 +17,7 @@ namespace ArguMint.UnitTests.Helpers
 
          try
          {
-            return closedAnalyzeMethod.Invoke( argumentAnalyzer, parameters );
+            return closedAnalyzeMethod.Invoke( null, parameters );
          }
          catch ( TargetInvocationException ex ) when ( ex.InnerException != null )
          {

--- a/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
+++ b/src/ArguMint/ArguMint/ArgumentAnalyzer.cs
@@ -8,7 +8,7 @@ namespace ArguMint
       private readonly IHandlerDispatcher _handlerDispatcher;
       private readonly IRuleMatcher _ruleMatcher;
 
-      public ArgumentAnalyzer()
+      private ArgumentAnalyzer()
       {
          _handlerDispatcher = new HandlerDispatcher( new TypeInspector() );
          _ruleMatcher = new RuleMatcher( new RuleProvider(), new TypeInspector() );
@@ -20,7 +20,10 @@ namespace ArguMint
          _ruleMatcher = ruleMatcher;
       }
 
-      public T Analyze<T>( string[] arguments ) where T : class, new()
+      public static T Analyze<T>( string[] arguments ) where T : class, new()
+         => new ArgumentAnalyzer().AnalyzeCore<T>( arguments );
+
+      internal T AnalyzeCore<T>( string[] arguments ) where T : class, new()
       {
          if ( arguments == null )
          {


### PR DESCRIPTION
Instead, moved it into a public static method so users can one-line it, rather than making one just to call one method on it.

Moved the real analysis into an AnalyzeCore method. Updated all uses:

- Integration tests now use the static method
- Unit tests will still create an instance, but now call AnalyzeCore

This lets integration tests use the real API that users will use; unit tests are allowed to reach into the internal constructor for dependency injection. I tried having an internal static Analyze that accepted string args and also the dependencies, but it was too ugly--this is better.