### PR TITLE
Enum validation

### DIFF
--- a/src/ArguMint/ArguMint.UnitTests/ArguMint.UnitTests.csproj
+++ b/src/ArguMint/ArguMint.UnitTests/ArguMint.UnitTests.csproj
@@ -86,6 +86,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ArgumentAttributeTests.cs" />
     <Compile Include="Dummies\ClassWithOneMarkedPrivateInstanceMethod.cs" />
     <Compile Include="Dummies\ClassWithOneMarkedPrivateStaticMethod.cs" />
     <Compile Include="Dummies\ClassWithOneMarkedPublicInstanceMethod.cs" />

--- a/src/ArguMint/ArguMint.UnitTests/ArgumentAttributeTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/ArgumentAttributeTests.cs
@@ -1,6 +1,25 @@
-﻿namespace ArguMint.UnitTests
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+namespace ArguMint.UnitTests
 {
    public class ArgumentAttributeTests
    {
+      [Fact]
+      public void Ctor_SpacingParameterIsLessThanEnumBase_ThrowsArgumentOutOfRangeException()
+      {
+         Action ctor = () => new ArgumentAttribute( "DoesNotMatter", Spacing.None - 1 );
+
+         ctor.ShouldThrow<ArgumentOutOfRangeException>();
+      }
+
+      [Fact]
+      public void Ctor_SpacingParameterIsGreaterThanEnumBounds_ThrowsArgumentOutOfRangeException()
+      {
+         Action ctor = () => new ArgumentAttribute( "DoesNotMatter", Spacing.Postfix + 1 );
+
+         ctor.ShouldThrow<ArgumentOutOfRangeException>();
+      }
    }
 }

--- a/src/ArguMint/ArguMint.UnitTests/ArgumentAttributeTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/ArgumentAttributeTests.cs
@@ -1,0 +1,6 @@
+﻿namespace ArguMint.UnitTests
+{
+   public class ArgumentAttributeTests
+   {
+   }
+}

--- a/src/ArguMint/ArguMint.UnitTests/ArgumentPositionExtensionsTests.cs
+++ b/src/ArguMint/ArguMint.UnitTests/ArgumentPositionExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using Xunit;
 
 namespace ArguMint.UnitTests
@@ -33,6 +34,26 @@ namespace ArguMint.UnitTests
          int index = argumentPosition.ToIndex();
 
          index.Should().Be( 1 );
+      }
+
+      [Fact]
+      public void ToIndex_PositionIsBelowTheFirstOption_ThrowsArgumentOutOfRangeException()
+      {
+         var argumentPosition = ArgumentPosition.Any - 1;
+
+         Action toIndex = () => argumentPosition.ToIndex();
+
+         toIndex.ShouldThrow<ArgumentOutOfRangeException>();
+      }
+
+      [Fact]
+      public void ToIndex_PositionIsAboveTheLastOption_ThrowsArgumentOutOfRangeException()
+      {
+         var argumentPosition = ArgumentPosition.Tenth + 1;
+
+         Action toIndex = () => argumentPosition.ToIndex();
+
+         toIndex.ShouldThrow<ArgumentOutOfRangeException>();
       }
    }
 }

--- a/src/ArguMint/ArguMint/ArgumentAttribute.cs
+++ b/src/ArguMint/ArguMint/ArgumentAttribute.cs
@@ -33,6 +33,11 @@ namespace ArguMint
       public ArgumentAttribute( string argument, Spacing spacing )
          : this( argument )
       {
+         if ( spacing < Spacing.None || spacing > Spacing.Postfix )
+         {
+            throw new ArgumentOutOfRangeException( nameof( spacing ), $"Spacing parameter value was out of range: {(int) spacing}" );
+         }
+
          Spacing = spacing;
       }
    }

--- a/src/ArguMint/ArguMint/ArgumentPositionExtensions.cs
+++ b/src/ArguMint/ArguMint/ArgumentPositionExtensions.cs
@@ -1,8 +1,17 @@
-﻿namespace ArguMint
+﻿using System;
+
+namespace ArguMint
 {
    internal static class ArgumentPositionExtensions
    {
       public static int ToIndex( this ArgumentPosition argumentPosition )
-         => (int) argumentPosition - (int) ArgumentPosition.First;
+      {
+         if ( argumentPosition < ArgumentPosition.Any || argumentPosition > ArgumentPosition.Tenth )
+         {
+            throw new ArgumentOutOfRangeException( nameof( argumentPosition ), $"Argument position parameter value was out of range: {(int) argumentPosition}" );
+         }
+
+         return (int) argumentPosition - (int) ArgumentPosition.First;
+      }
    }
 }

--- a/src/ArguMint/ArguMint/ArgumentPositionExtensions.cs
+++ b/src/ArguMint/ArguMint/ArgumentPositionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿namespace ArguMint
 {
-   public static class ArgumentPositionExtensions
+   internal static class ArgumentPositionExtensions
    {
       public static int ToIndex( this ArgumentPosition argumentPosition )
          => (int) argumentPosition - (int) ArgumentPosition.First;


### PR DESCRIPTION
Now throws when enums are used, to proactively ensure that they're within valid ranges. This would be an edge case of misuse, but would save the user from doing something dumb. In this case, it'd be using an int, cast to an enum value, which is outside the values it supports.